### PR TITLE
Move district dropdown inside h1 tag

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -354,13 +354,12 @@ export default function Home(): React.ReactElement {
         <div className="flex flex-col gap-6">
           {/* Page Title with District Selector */}
           <div className="space-y-3">
-            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-              <h1 className="text-3xl sm:text-4xl font-bold text-neutral-950 tracking-tight">{currentDistrictName} Power Outage Information</h1>
+            <h1 className="text-3xl sm:text-4xl font-bold text-neutral-950 tracking-tight">
               <select
                 id="district-select"
                 value={selectedDistrict}
                 onChange={(e) => setSelectedDistrict(e.target.value)}
-                className="w-full sm:w-auto px-4 py-2 border border-neutral-300 rounded-lg bg-white text-neutral-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all text-sm sm:text-base"
+                className="font-bold bg-transparent border-b-2 border-neutral-300 focus:border-blue-500 focus:outline-none mr-2 pr-8 cursor-pointer hover:border-neutral-400 transition-colors"
                 aria-label="Select District"
               >
                 {DISTRICTS.map((district) => (
@@ -369,7 +368,8 @@ export default function Home(): React.ReactElement {
                   </option>
                 ))}
               </select>
-            </div>
+              Power Outage Information
+            </h1>
             {data.length > 0 && (
               <p className="text-base text-neutral-600 max-w-prose">
                 Real-time outage data, automatically refreshed every 5 minutes.


### PR DESCRIPTION
- Dropdown now appears inline within the page heading
- Styled with transparent background and bottom border
- Heading reads: '[District] Power Outage Information'
- More integrated and natural appearance
- Maintains bold font styling consistent with h1