### PR TITLE
Fix time formatting removing leading zeros

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,7 +33,7 @@ const columns: ColumnDef<DHBVNData>[] = [
     cell: ({ row }: { row: Row<DHBVNData> }) => {
       const value = row.getValue('start_time') as string;
       const date = parseOutageDate(value);
-      return date ? format(date, 'PPpp') : value;
+      return date ? format(date, 'dd-MMM-yyyy hh:mm:ss a') : value;
     },
   },
   {
@@ -42,7 +42,7 @@ const columns: ColumnDef<DHBVNData>[] = [
     cell: ({ row }: { row: Row<DHBVNData> }) => {
       const value = row.getValue('restoration_time') as string;
       const date = parseOutageDate(value);
-      return date ? format(date, 'PPpp') : value;
+      return date ? format(date, 'dd-MMM-yyyy hh:mm:ss a') : value;
     },
   },
   {


### PR DESCRIPTION
Changed format string from 'PPpp' to 'dd-MMM-yyyy hh:mm:ss a' to ensure hours display with leading zeros (e.g., 09:14:12 AM instead of 9:14:12 AM) for both start_time and restoration_time fields.