### PR TITLE
Fix invalid time value error

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -13,7 +13,12 @@ export function parseOutageDate(dateStr: string): Date | null {
     if (!datePart || !timePart) return null;
 
     const [day, month, year] = datePart.split('-');
-    return new Date(`${year}-${month}-${day} ${timePart}`);
+    const date = new Date(`${year}-${month}-${day} ${timePart}`);
+
+    // Check if the date is valid
+    if (isNaN(date.getTime())) return null;
+
+    return date;
   } catch {
     return null;
   }


### PR DESCRIPTION
…value error

Add validation check using isNaN(date.getTime()) to ensure parseOutageDate returns null for invalid dates instead of returning an invalid Date object. This prevents RangeError when date-fns format() receives an invalid Date.

Fixes the error: RangeError: Invalid time value