### PR TITLE
Sort district dropdown options alphabetically

### DIFF
--- a/components/DistrictSelect.tsx
+++ b/components/DistrictSelect.tsx
@@ -7,7 +7,7 @@ import { DISTRICTS as DB_DISTRICTS } from '@/lib/database/subscriptions';
 const DISTRICTS = DB_DISTRICTS.map(d => ({
     value: d.id.toString(),
     label: d.name
-}));
+})).sort((a, b) => a.label.localeCompare(b.label));
 
 interface DistrictSelectProps {
     value: string;


### PR DESCRIPTION
### Motivation
- Make the district dropdown easier to scan by presenting options in alphabetical order.

### Description
- Add `.sort((a, b) => a.label.localeCompare(b.label))` to the `DISTRICTS` mapping in `components/DistrictSelect.tsx` so the dropdown options are rendered alphabetically.

### Testing
- Started the dev server with `npm run dev` and ran a Playwright script to open the page and capture a screenshot which completed and produced `artifacts/district-dropdown-sorted.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b962dd1e88332a9ef676efc89799e)